### PR TITLE
Update prodacity event page to v2

### DIFF
--- a/modules/prodacity-page/views/page.html
+++ b/modules/prodacity-page/views/page.html
@@ -2,7 +2,7 @@
 
 {% block main %}
 <script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", function(event) {
+  document.addEventListener('DOMContentLoaded', function (event) {
     (function () {
       document.getElementById('prodacity-banner').classList.add('hidden');
     })();
@@ -26,12 +26,14 @@
           This year's theme is Prod Academy, which will set a baseline for how to do DevOps in
           government and achieve mission outcomes.
           <br/><br/>
-          Attendees will leave knowing how to start and scale the next generation of government
-          software organizations with the lessons learned to do it better, faster, and cheaper.
+          <strong>Attendees will learn how to launch, scale, and continuously improve the next
+            generation of government software organizations with the lessons learned to do it
+            better, faster, and cheaper.</strong>
         </div>
       </div>
       <div class="center-button">
-        <custom-button text="Register Now" link="https://rise8.regfox.com/prodacity-2022" mode="gradient"
+        <custom-button text="Register Now" link="https://rise8.regfox.com/prodacity-2022"
+                       mode="gradient"
                        text-style="font-weight: 700"
                        half no-chevron></custom-button>
       </div>
@@ -41,36 +43,47 @@
         <div class="two-column-wrapper">
           <div class="section-body-text">
             <div class="agenda-header">Day 1: Why & What</div>
+            <p>Day 1 starts with why and clarifies the what. Josh Marcuse will discuss the "Digital
+              Value Chain" as it relates to the future battlefield. Then, Gene Kim will keynote the
+              research behind high performing software teams and what we need to focus on as a
+              community. The rest of day 1 covers the "what" of these teams.</p>
             <ul class="no-bullet-list">
               <li>The SW-Powered Battlefield w/Josh Marcuse</li>
               <li>Outputs, Outcomes, Impacts</li>
-              <li>Keynote | SDO Performance and Mission Success w/ Gene Kim</li>
+              <li><strong>Keynote</strong> | SDO Performance and Mission Success w/ <strong>Gene
+                Kim</strong></li>
               <li>NUMMI Maneuver and the “that won’t work here” myth</li>
               <li>Balanced Teams w/ Janice Fraser</li>
               <li>Working backwards from the user</li>
-              <li>Product Practices</li>
-              <li>The Real Deal on cATO</li>
-              <li>Panel | Infrastructure</li>
-              <li>Cloud-native Platform and DevOps outcomes in Public Sector</li>
-              <li>Panel | PaaS</li>
+              <li>Product Practices w/ Adam Furtado</li>
+              <li>The Real Deal on cATO w/ Angel Phaneuf and Bryon Kroger</li>
+              <li><strong>Panel</strong> | Infrastructure</li>
+              <li>Cloud-native Platform and DevOps outcomes in Public Sector w/Cornelia Davis</li>
+              <li><strong>Panel</strong> | PaaS</li>
               <li>The Culture Manifesto w/ Bryon Kroger</li>
               <li>Transformational Leadership w/ Gene Kim</li>
             </ul>
           </div>
           <div class="section-body-text">
             <div class="agenda-header">Day 2: How</div>
+            <p>Day 2 is all about the how. We will talk about how to do software, and also the
+              requirements (JCIDS), budgeting (PPBE), and acquisitions strategy (DAS). That will be
+              underpinned by a focus on learning fast keynoted by Admiral John Richardson USN
+              (retired).</p>
             <ul class="no-bullet-list">
-              <li>Keynote | Learn the Fastest w/ Admiral John Richardson USN (retired), 31st CNO</li>
+              <li><strong>Keynote</strong> | Learn the Fastest w/ Admiral <strong>John Richardson</strong> USN (retired), 31st CNO
+              </li>
               <li>DevOps Enterprise Forum: Authority and Accountability w/ Lt Col Max Reele</li>
               <li>Funding Teams instead of Solutions</li>
               <li>A New Model for SW Program Accountability</li>
               <li>People Ops in Government</li>
-              <li>Panel | Hacking Gov HR</li>
+              <li><strong>Panel</strong> | Hacking Gov HR</li>
               <li>Innovation Strategies for DAS w/ Meagan Metzger and Riya Patel</li>
               <li>Innovation Strategies for PPBE</li>
-              <li>Innovation Strategies/Tactics for Execs and Sr Stakeholders w/ Siobhan McFeeney</li>
+              <li>Innovation Strategies/Tactics for Execs and Sr Stakeholders w/ Siobhan McFeeney
+              </li>
               <li>Measuring customer obsession - don't talk about it, be about it</li>
-              <li>Panel | You get what you measure</li>
+              <li><strong>Panel</strong> | You get what you measure</li>
               <li>Getting Started & Call to Action</li>
             </ul>
           </div>
@@ -99,7 +112,8 @@
       </div>
     </div>
     <div class="center-button">
-      <custom-button text="Register Now" link="https://rise8.regfox.com/prodacity-2022" mode="gradient"
+      <custom-button text="Register Now" link="https://rise8.regfox.com/prodacity-2022"
+                     mode="gradient"
                      text-style="font-weight: 700"
                      half no-chevron></custom-button>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apostrophecms/seo": "^1.1.1",
         "@apostrophecms/sitemap": "^1.0.1",
-        "apostrophe": "^3.22.0",
+        "apostrophe": "3.21.1",
         "normalize.css": "^8.0.1"
       },
       "devDependencies": {
@@ -3280,9 +3280,9 @@
       }
     },
     "node_modules/apostrophe": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-3.22.0.tgz",
-      "integrity": "sha512-EuhSmRbmM6dXsWxwC1NibG/6Titl6idwWF40CQ+4PJRvAl+aVOpqYav7CP2aZG6M9yCUThlNl30budGqU1dWIw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-3.21.1.tgz",
+      "integrity": "sha512-iD04Ne5cixqYKAfjPGo4ev93NuEW3D8EjAFC10JGbWyMwjWRDPKQ7yzG37gGsL7fx+7Y3d/Ztg7S/5yg2+ujEg==",
       "dependencies": {
         "@apostrophecms/vue-color": "^2.8.2",
         "@babel/core": "^7.16.7",
@@ -3446,6 +3446,22 @@
         "snappy": {
           "optional": true
         }
+      }
+    },
+    "node_modules/apostrophe/node_modules/sass": {
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.1.tgz",
+      "integrity": "sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/argparse": {
@@ -10787,9 +10803,11 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.1.tgz",
-      "integrity": "sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.53.0.tgz",
+      "integrity": "sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -15352,9 +15370,9 @@
       }
     },
     "apostrophe": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-3.22.0.tgz",
-      "integrity": "sha512-EuhSmRbmM6dXsWxwC1NibG/6Titl6idwWF40CQ+4PJRvAl+aVOpqYav7CP2aZG6M9yCUThlNl30budGqU1dWIw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-3.21.1.tgz",
+      "integrity": "sha512-iD04Ne5cixqYKAfjPGo4ev93NuEW3D8EjAFC10JGbWyMwjWRDPKQ7yzG37gGsL7fx+7Y3d/Ztg7S/5yg2+ujEg==",
       "requires": {
         "@apostrophecms/vue-color": "^2.8.2",
         "@babel/core": "^7.16.7",
@@ -15484,6 +15502,16 @@
             "optional-require": "^1.1.8",
             "safe-buffer": "^5.1.2",
             "saslprep": "^1.0.0"
+          }
+        },
+        "sass": {
+          "version": "1.52.1",
+          "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.1.tgz",
+          "integrity": "sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==",
+          "requires": {
+            "chokidar": ">=3.0.0 <4.0.0",
+            "immutable": "^4.0.0",
+            "source-map-js": ">=0.6.2 <2.0.0"
           }
         }
       }
@@ -20953,9 +20981,11 @@
       }
     },
     "sass": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.1.tgz",
-      "integrity": "sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.53.0.tgz",
+      "integrity": "sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@apostrophecms/seo": "^1.1.1",
     "@apostrophecms/sitemap": "^1.0.1",
-    "apostrophe": "^3.22.0",
+    "apostrophe": "3.21.1",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a small update to the prodacity event page for existing components. I'm also rolling back to apostrophe version 3.21.1 for the moment as 18 days ago a bug was introduced that breaks a lot of functionality in 3.22.0.